### PR TITLE
Removed VIEW SITE link in Admin Page

### DIFF
--- a/info/urls.py
+++ b/info/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 from . import views
-
+from django.contrib import admin
 
 urlpatterns = [
     path('', views.index, name='index'),
@@ -34,3 +34,5 @@ urlpatterns = [
     path('teacher/<int:marks_c_id>/Edit_marks/', views.edit_marks, name='edit_marks'),
 
 ]
+admin.site.site_url= None
+admin.site.site_header = 'My Site'


### PR DESCRIPTION
Removed the View site link in the Admin page to avoid looping in login.